### PR TITLE
CSV/TSV ingestion with cache

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +58,18 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-broadcast"
@@ -238,6 +262,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -459,6 +497,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -865,6 +909,18 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1352,9 +1408,27 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1845,6 +1919,17 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2882,6 +2967,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.10.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3509,6 +3608,8 @@ dependencies = [
 name = "tauri-app"
 version = "0.1.0"
 dependencies = [
+ "blake3",
+ "rusqlite",
  "serde",
  "serde_json",
  "tauri",
@@ -4175,6 +4276,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,8 +18,9 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
-tauri-plugin-opener = "2"
+blake3 = "1"
+rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-
+tauri = { version = "2", features = [] }
+tauri-plugin-opener = "2"

--- a/src-tauri/src/core.rs
+++ b/src-tauri/src/core.rs
@@ -1,0 +1,232 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tauri::{AppHandle, Manager};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Candle {
+    pub ts_utc: String,
+    pub open: f64,
+    pub high: f64,
+    pub low: f64,
+    pub close: f64,
+    pub volume: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DataSet {
+    pub source_path: String,
+    pub candles: Vec<Candle>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct IngestResult {
+    pub dataset: DataSet,
+    pub used_cache: bool,
+}
+
+fn cache_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let base = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| e.to_string())?;
+    Ok(base.join("cache"))
+}
+
+fn cache_key(path: &Path) -> Result<String, String> {
+    let meta = fs::metadata(path).map_err(|e| e.to_string())?;
+    let mtime = meta.modified().map_err(|e| e.to_string())?;
+    let mtime = mtime
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| e.to_string())?
+        .as_secs();
+    Ok(format!("{}_{}", path.to_string_lossy(), mtime))
+}
+
+fn cache_path(app: &AppHandle, key: &str) -> Result<PathBuf, String> {
+    Ok(cache_dir(app)?.join(format!("{}.sqlite", blake3::hash(key.as_bytes()))))
+}
+
+pub fn clear_cache(app: &AppHandle) -> Result<u64, String> {
+    let dir = cache_dir(app)?;
+    if !dir.exists() {
+        return Ok(0);
+    }
+    let mut removed = 0;
+    for entry in fs::read_dir(&dir).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) == Some("sqlite") {
+            fs::remove_file(&path).map_err(|e| e.to_string())?;
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
+
+pub fn load_csv_or_tsv(app: &AppHandle, path: &str) -> Result<IngestResult, String> {
+    let path = PathBuf::from(path);
+    if !path.exists() {
+        return Err("file not found".to_string());
+    }
+
+    let key = cache_key(&path)?;
+    let cache_path = cache_path(app, &key)?;
+
+    if cache_path.exists() {
+        let dataset = load_from_cache(&cache_path)?;
+        return Ok(IngestResult {
+            dataset,
+            used_cache: true,
+        });
+    }
+
+    let dataset = parse_csv_like(&path)?;
+    save_to_cache(&cache_path, &dataset)?;
+
+    Ok(IngestResult {
+        dataset,
+        used_cache: false,
+    })
+}
+
+fn parse_csv_like(path: &Path) -> Result<DataSet, String> {
+    let content = fs::read_to_string(path).map_err(|e| e.to_string())?;
+    let mut candles = Vec::new();
+
+    for (idx, line) in content.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        // Allow comments or header-like lines
+        if idx == 0 && line.to_lowercase().contains("timestamp") {
+            continue;
+        }
+        let parts = split_line(line);
+        if parts.len() < 5 {
+            return Err(format!("invalid column count at line {}", idx + 1));
+        }
+        let ts_raw = parts[0].trim();
+        let ts_utc = normalize_timestamp(ts_raw)?;
+        let open = parse_f64(parts[1])?;
+        let high = parse_f64(parts[2])?;
+        let low = parse_f64(parts[3])?;
+        let close = parse_f64(parts[4])?;
+        let volume = if parts.len() >= 6 {
+            parse_f64(parts[5])?
+        } else {
+            0.0
+        };
+
+        candles.push(Candle {
+            ts_utc,
+            open,
+            high,
+            low,
+            close,
+            volume,
+        });
+    }
+
+    Ok(DataSet {
+        source_path: path.to_string_lossy().to_string(),
+        candles,
+    })
+}
+
+fn split_line(line: &str) -> Vec<&str> {
+    if line.contains('\t') {
+        line.split('\t').collect()
+    } else if line.contains(',') {
+        line.split(',').collect()
+    } else {
+        line.split_whitespace().collect()
+    }
+}
+
+pub fn normalize_timestamp(s: &str) -> Result<String, String> {
+    // expected: YYYY.MM.DD H:MM:SS (UTC)
+    if let Some((date, time)) = s.split_once(' ') {
+        let date = date.replace('.', "-");
+        return Ok(format!("{}T{}Z", date, time));
+    }
+    if let Some((date, time)) = s.split_once('\t') {
+        let date = date.replace('.', "-");
+        return Ok(format!("{}T{}Z", date, time));
+    }
+    Err("invalid timestamp format".to_string())
+}
+
+fn parse_f64(s: &str) -> Result<f64, String> {
+    let cleaned = s.trim().replace(',', "");
+    cleaned
+        .parse::<f64>()
+        .map_err(|_| format!("invalid number: {}", s))
+}
+
+fn save_to_cache(path: &Path, dataset: &DataSet) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let mut conn = rusqlite::Connection::open(path).map_err(|e| e.to_string())?;
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS dataset_meta (source_path TEXT);\n         CREATE TABLE IF NOT EXISTS candles (ts_utc TEXT, open REAL, high REAL, low REAL, close REAL, volume REAL);",
+    )
+    .map_err(|e| e.to_string())?;
+    conn.execute("DELETE FROM dataset_meta", []).map_err(|e| e.to_string())?;
+    conn.execute("INSERT INTO dataset_meta (source_path) VALUES (?1)", [&dataset.source_path])
+        .map_err(|e| e.to_string())?;
+    conn.execute("DELETE FROM candles", []).map_err(|e| e.to_string())?;
+
+    let tx = conn.transaction().map_err(|e| e.to_string())?;
+    {
+        let mut stmt = tx
+            .prepare("INSERT INTO candles (ts_utc, open, high, low, close, volume) VALUES (?1, ?2, ?3, ?4, ?5, ?6)")
+            .map_err(|e| e.to_string())?;
+        for c in &dataset.candles {
+            stmt.execute((
+                &c.ts_utc,
+                c.open,
+                c.high,
+                c.low,
+                c.close,
+                c.volume,
+            ))
+            .map_err(|e| e.to_string())?;
+        }
+    }
+    tx.commit().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn load_from_cache(path: &Path) -> Result<DataSet, String> {
+    let conn = rusqlite::Connection::open(path).map_err(|e| e.to_string())?;
+    let source_path: String = conn
+        .query_row("SELECT source_path FROM dataset_meta LIMIT 1", [], |row| row.get(0))
+        .map_err(|e| e.to_string())?;
+
+    let mut stmt = conn
+        .prepare("SELECT ts_utc, open, high, low, close, volume FROM candles ORDER BY ROWID ASC")
+        .map_err(|e| e.to_string())?;
+
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(Candle {
+                ts_utc: row.get(0)?,
+                open: row.get(1)?,
+                high: row.get(2)?,
+                low: row.get(3)?,
+                close: row.get(4)?,
+                volume: row.get(5)?,
+            })
+        })
+        .map_err(|e| e.to_string())?;
+
+    let mut candles = Vec::new();
+    for row in rows {
+        candles.push(row.map_err(|e| e.to_string())?);
+    }
+
+    Ok(DataSet { source_path, candles })
+}

--- a/src-tauri/src/core_tests.rs
+++ b/src-tauri/src/core_tests.rs
@@ -1,0 +1,10 @@
+#[cfg(test)]
+mod tests {
+    use super::super::core::normalize_timestamp;
+
+    #[test]
+    fn normalize_timestamp_works() {
+        let ts = normalize_timestamp("2003.05.05 0:01:00").unwrap();
+        assert_eq!(ts, "2003-05-05T0:01:00Z");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,14 +1,23 @@
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
+
+mod core;
+mod core_tests;
+
 #[tauri::command]
-fn greet(name: &str) -> String {
-    format!("Hello, {}! You've been greeted from Rust!", name)
+fn ingest_csv(path: &str, app: tauri::AppHandle) -> Result<core::IngestResult, String> {
+    core::load_csv_or_tsv(&app, path)
+}
+
+#[tauri::command]
+fn clear_cache(app: tauri::AppHandle) -> Result<u64, String> {
+    core::clear_cache(&app)
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![greet])
+        .invoke_handler(tauri::generate_handler![ingest_csv, clear_cache])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }


### PR DESCRIPTION
# 概要
- CSV/TSV 取り込み + SQLite キャッシュを実装
- UTC 変換・簡易検証・キャッシュ削除コマンドを追加

# 検証
- `cargo test -p tauri-app --manifest-path src-tauri/Cargo.toml`

# CI
- 必須: なし (未実施)
- 任意: なし (未実施)

# ロールバック
- このPRをrevert

# リンク
- closes #3