### PR TITLE
Add preset persistence

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod core_tests;
 mod indicators;
 mod indicators_tests;
 mod resample;
+mod presets;
 
 #[allow(dead_code)]
 fn _infer_interval_unused() {
@@ -53,6 +54,26 @@ fn resample_dataset(dataset: core::DataSet, target: String) -> Result<core::Data
     resample::resample(&dataset, interval)
 }
 
+#[tauri::command]
+fn list_presets(app: tauri::AppHandle) -> Result<Vec<presets::Preset>, String> {
+    presets::list_presets(&app)
+}
+
+#[tauri::command]
+fn save_preset(app: tauri::AppHandle, preset: presets::Preset) -> Result<(), String> {
+    presets::save_preset(&app, preset)
+}
+
+#[tauri::command]
+fn delete_preset(app: tauri::AppHandle, name: &str) -> Result<bool, String> {
+    presets::delete_preset(&app, name)
+}
+
+#[tauri::command]
+fn load_preset(app: tauri::AppHandle, name: &str) -> Result<presets::Preset, String> {
+    presets::load_preset(&app, name)
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -61,7 +82,11 @@ pub fn run() {
             ingest_csv,
             clear_cache,
             compute_indicators,
-            resample_dataset
+            resample_dataset,
+            list_presets,
+            save_preset,
+            delete_preset,
+            load_preset
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/presets.rs
+++ b/src-tauri/src/presets.rs
@@ -1,0 +1,84 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PaneState {
+    pub id: usize,
+    pub pair: String,
+    pub timeframe: String,
+    pub indicator: String,
+    pub playing: bool,
+    pub speed: f64,
+    pub seek: i64,
+    pub bars: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Preset {
+    pub name: String,
+    pub split: usize,
+    pub panes: Vec<PaneState>,
+}
+
+fn presets_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let base = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| e.to_string())?;
+    Ok(base.join("presets.json"))
+}
+
+fn load_all(app: &AppHandle) -> Result<Vec<Preset>, String> {
+    let path = presets_path(app)?;
+    if !path.exists() {
+        return Ok(vec![]);
+    }
+    let data = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    let presets: Vec<Preset> = serde_json::from_str(&data).map_err(|e| e.to_string())?;
+    Ok(presets)
+}
+
+fn save_all(app: &AppHandle, presets: &[Preset]) -> Result<(), String> {
+    let path = presets_path(app)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let data = serde_json::to_string_pretty(presets).map_err(|e| e.to_string())?;
+    fs::write(&path, data).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+pub fn list_presets(app: &AppHandle) -> Result<Vec<Preset>, String> {
+    load_all(app)
+}
+
+pub fn save_preset(app: &AppHandle, preset: Preset) -> Result<(), String> {
+    if preset.name.trim().is_empty() {
+        return Err("preset name is required".to_string());
+    }
+    let mut presets = load_all(app)?;
+    presets.retain(|p| p.name != preset.name);
+    presets.push(preset);
+    save_all(app, &presets)
+}
+
+pub fn delete_preset(app: &AppHandle, name: &str) -> Result<bool, String> {
+    let mut presets = load_all(app)?;
+    let before = presets.len();
+    presets.retain(|p| p.name != name);
+    if presets.len() == before {
+        return Ok(false);
+    }
+    save_all(app, &presets)?;
+    Ok(true)
+}
+
+pub fn load_preset(app: &AppHandle, name: &str) -> Result<Preset, String> {
+    let presets = load_all(app)?;
+    presets
+        .into_iter()
+        .find(|p| p.name == name)
+        .ok_or_else(|| "preset not found".to_string())
+}

--- a/src/App.css
+++ b/src/App.css
@@ -53,7 +53,8 @@ body {
 .split-toggle button,
 .segmented button,
 .ghost,
-.list-item {
+.list-item,
+.preset-item button {
   border: 1px solid transparent;
   background: transparent;
   color: var(--text);
@@ -83,7 +84,7 @@ body {
 
 .layout {
   display: grid;
-  grid-template-columns: 240px 1fr 260px;
+  grid-template-columns: 240px 1fr 320px;
   height: 100%;
 }
 
@@ -192,6 +193,35 @@ input[type="range"] {
   margin-top: 6px;
   font-size: 12px;
   color: var(--muted);
+}
+
+.preset-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.preset-row input {
+  background: #0f1118;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  padding: 8px;
+}
+
+.preset-list {
+  display: grid;
+  gap: 6px;
+}
+
+.preset-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px;
 }
 
 @media (max-width: 1100px) {


### PR DESCRIPTION
# 概要
- プリセット保存/読込/削除（app data に保存）を追加
- 分割レイアウトと再生状態も保存対象に含める

# 検証
- `npm run tauri dev`

# CI
- 必須: なし (未実施)
- 任意: なし (未実施)

# ロールバック
- このPRをrevert

# リンク
- closes #7