### PR TITLE
Wire CSV ingestion to UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -253,3 +253,15 @@ input[type="range"] {
     gap: 6px;
   }
 }
+
+.ingest-info {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.ingest-error {
+  margin-top: 8px;
+  font-size: 12px;
+  color: #ff6b6b;
+}


### PR DESCRIPTION
# 概要
- CSV選択→ingest→状態反映のUI配線を追加
- 読み込み失敗時のエラー表示を追加

# 検証
- `npm run tauri dev` （こちらの環境では `tauri` コマンドが見つからず実行不可）

# CI
- 必須: なし (未実施)
- 任意: なし (未実施)

# ロールバック
- このPRをrevert

# リンク
- closes #17