### PR TITLE
Refine CSV/TSV ingest spec handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -179,7 +179,7 @@ function App() {
           {ingestInfo ? (
             <div className="ingest-info">
               <div>rows: {ingestInfo.rows}</div>
-              <div>cache: {ingestInfo.usedCache ? "hit" : "miss"}</div>
+              <div>cache: {ingestInfo.usedCache ? "hit (cached)" : "miss (parsed)"}</div>
             </div>
           ) : null}
           {ingestError ? <div className="ingest-error">{ingestError}</div> : null}


### PR DESCRIPTION
# 概要
- CSV/TSV取り込みのtimestamp判定をSpecに合わせて拡張
- 時刻のゼロ埋め正規化を追加
- cache hit/miss表示を明確化

# 検証
- 未実施（lint/testスクリプト無し）

# CI
- 必須: 未設定
- 任意: 未設定

# ロールバック
- このPRのコミットをrevert

# リンク
- Closes #34
