### PR TITLE
Wire playback controls and 1-bar seek

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -247,6 +247,12 @@ input[type="range"] {
   color: var(--muted);
 }
 
+.seek-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+
 .preset-row {
   display: grid;
   grid-template-columns: 1fr auto auto;


### PR DESCRIPTION
# 概要
- 再生/一時停止/速度の状態をUIと同期
- 1バー単位のシーク操作を追加
- シークとチャート表示を連動

# 検証
- 未実施（lint/testスクリプト無し）

# CI
- 必須: 未設定
- 任意: 未設定

# ロールバック
- このPRのコミットをrevert

# リンク
- Closes #35
