### PR TITLE
Persist full preset pane state

### DIFF
--- a/src-tauri/src/presets.rs
+++ b/src-tauri/src/presets.rs
@@ -9,6 +9,8 @@ pub struct PaneState {
     pub pair: String,
     pub timeframe: String,
     pub indicator: String,
+    pub view_bars: i64,
+    pub view_offset: i64,
     pub playing: bool,
     pub speed: f64,
     pub seek: i64,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -143,7 +143,18 @@ function App() {
       preset: {
         name: presetName,
         split,
-        panes: paneState,
+        panes: paneState.map((pane) => ({
+          id: pane.id,
+          pair: pane.pair,
+          timeframe: pane.timeframe,
+          indicator: pane.indicator,
+          view_bars: pane.viewBars,
+          view_offset: pane.viewOffset,
+          playing: false,
+          speed: pane.speed,
+          seek: pane.seek,
+          bars: pane.bars,
+        })),
       },
     });
     await refreshPresets();
@@ -153,7 +164,20 @@ function App() {
   const loadPreset = async (name) => {
     const preset = await invoke("load_preset", { name });
     setSplit(preset.split);
-    setPaneState(preset.panes);
+    setPaneState(
+      preset.panes.map((pane, idx) => ({
+        ...emptyPane(idx),
+        id: pane.id ?? idx,
+        pair: pane.pair,
+        timeframe: pane.timeframe,
+        indicator: pane.indicator,
+        viewBars: pane.view_bars ?? 240,
+        viewOffset: pane.view_offset ?? 0,
+        speed: pane.speed,
+        seek: pane.seek,
+        bars: pane.bars,
+      }))
+    );
     setActivePane(0);
   };
 


### PR DESCRIPTION
# 概要
- プリセットに viewBars/viewOffset を追加保存
- 読み込み時に viewBars/viewOffset を復元

# 検証
- 未実施（lint/testスクリプト無し）

# CI
- 必須: 未設定
- 任意: 未設定

# ロールバック
- このPRのコミットをrevert

# リンク
- Closes #40
