### PR TITLE
Clarify UTC handling

### DIFF
--- a/src-tauri/src/core.rs
+++ b/src-tauri/src/core.rs
@@ -198,7 +198,7 @@ fn parse_csv_like(path: &Path) -> Result<DataSet, String> {
         } else {
             (parts[0].trim().to_string(), 1)
         };
-        let ts_utc = normalize_timestamp(ts_raw).map_err(|e| format!("{} at line {}", e, idx + 1))?;
+        let ts_utc = normalize_timestamp(&ts_raw).map_err(|e| format!("{} at line {}", e, idx + 1))?;
         if parts.len() < start_idx + 4 {
             return Err(format!("invalid column count at line {}", idx + 1));
         }

--- a/src-tauri/src/core_tests.rs
+++ b/src-tauri/src/core_tests.rs
@@ -5,6 +5,12 @@ mod tests {
     #[test]
     fn normalize_timestamp_works() {
         let ts = normalize_timestamp("2003.05.05 0:01:00").unwrap();
-        assert_eq!(ts, "2003-05-05T0:01:00Z");
+        assert_eq!(ts, "2003-05-05T00:01:00Z");
+    }
+
+    #[test]
+    fn normalize_timestamp_is_utc() {
+        let ts = normalize_timestamp("2003.05.05 23:59:59").unwrap();
+        assert!(ts.ends_with('Z'));
     }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -467,7 +467,7 @@ function App() {
             >
               <div className="pane-header">
                 <span>{pane.pair}</span>
-                <span>{pane.timeframe}</span>
+                <span>{pane.timeframe} UTC</span>
               </div>
               <div className="pane-body">
                 <ChartCanvas


### PR DESCRIPTION
# 概要
- 表示ラベルにUTCを明記
- UTC正規化のテストを追加/修正

# 検証
- `cargo test -p tauri-app --quiet`

# CI
- 必須: 未設定
- 任意: 未設定

# ロールバック
- このPRのコミットをrevert

# リンク
- Closes #47
