### PR TITLE
perf: speed up CSV parsing

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -633,6 +633,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctor"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3638,6 +3659,7 @@ version = "0.1.0"
 dependencies = [
  "blake3",
  "chrono",
+ "csv",
  "rusqlite",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,4 +25,5 @@ serde_json = "1"
 chrono = { version = "0.4", features = ["clock"] }
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
+csv = "1.3"
 tauri-plugin-dialog = "2"


### PR DESCRIPTION
# 概要
- CSV/TSV読み込みをストリーム処理＋csvクレートに置き換え
- 空行/ヘッダ判定/時刻分割の互換維持

# 検証
- cargo test -q (src-tauri)

# CI
- 必須: N/A
- 任意: N/A

# ロールバック
- このPRの変更をrevert

# リンク
- closes #68
